### PR TITLE
enabled `getPublisher()` returns nullable String

### DIFF
--- a/lib/src/models/package_publisher_model.dart
+++ b/lib/src/models/package_publisher_model.dart
@@ -7,7 +7,7 @@ part 'package_publisher_model.g.dart';
 @freezed
 abstract class PackagePublisher with _$PackagePublisher {
   factory PackagePublisher({
-    required final String publisherId,
+    required final String? publisherId,
   }) = _PackagePublisher;
 
   factory PackagePublisher.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/models/package_publisher_model.freezed.dart
+++ b/lib/src/models/package_publisher_model.freezed.dart
@@ -20,7 +20,7 @@ PackagePublisher _$PackagePublisherFromJson(Map<String, dynamic> json) {
 class _$PackagePublisherTearOff {
   const _$PackagePublisherTearOff();
 
-  _PackagePublisher call({required String publisherId}) {
+  _PackagePublisher call({required String? publisherId}) {
     return _PackagePublisher(
       publisherId: publisherId,
     );
@@ -36,7 +36,7 @@ const $PackagePublisher = _$PackagePublisherTearOff();
 
 /// @nodoc
 mixin _$PackagePublisher {
-  String get publisherId => throw _privateConstructorUsedError;
+  String? get publisherId => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
   @JsonKey(ignore: true)
@@ -49,7 +49,7 @@ abstract class $PackagePublisherCopyWith<$Res> {
   factory $PackagePublisherCopyWith(
           PackagePublisher value, $Res Function(PackagePublisher) then) =
       _$PackagePublisherCopyWithImpl<$Res>;
-  $Res call({String publisherId});
+  $Res call({String? publisherId});
 }
 
 /// @nodoc
@@ -69,7 +69,7 @@ class _$PackagePublisherCopyWithImpl<$Res>
       publisherId: publisherId == freezed
           ? _value.publisherId
           : publisherId // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ));
   }
 }
@@ -81,7 +81,7 @@ abstract class _$PackagePublisherCopyWith<$Res>
           _PackagePublisher value, $Res Function(_PackagePublisher) then) =
       __$PackagePublisherCopyWithImpl<$Res>;
   @override
-  $Res call({String publisherId});
+  $Res call({String? publisherId});
 }
 
 /// @nodoc
@@ -103,7 +103,7 @@ class __$PackagePublisherCopyWithImpl<$Res>
       publisherId: publisherId == freezed
           ? _value.publisherId
           : publisherId // ignore: cast_nullable_to_non_nullable
-              as String,
+              as String?,
     ));
   }
 }
@@ -117,7 +117,7 @@ class _$_PackagePublisher implements _PackagePublisher {
       _$_$_PackagePublisherFromJson(json);
 
   @override
-  final String publisherId;
+  final String? publisherId;
 
   @override
   String toString() {
@@ -149,14 +149,14 @@ class _$_PackagePublisher implements _PackagePublisher {
 }
 
 abstract class _PackagePublisher implements PackagePublisher {
-  factory _PackagePublisher({required String publisherId}) =
+  factory _PackagePublisher({required String? publisherId}) =
       _$_PackagePublisher;
 
   factory _PackagePublisher.fromJson(Map<String, dynamic> json) =
       _$_PackagePublisher.fromJson;
 
   @override
-  String get publisherId => throw _privateConstructorUsedError;
+  String? get publisherId => throw _privateConstructorUsedError;
   @override
   @JsonKey(ignore: true)
   _$PackagePublisherCopyWith<_PackagePublisher> get copyWith =>

--- a/lib/src/models/package_publisher_model.g.dart
+++ b/lib/src/models/package_publisher_model.g.dart
@@ -8,7 +8,7 @@ part of 'package_publisher_model.dart';
 
 _$_PackagePublisher _$_$_PackagePublisherFromJson(Map<String, dynamic> json) {
   return _$_PackagePublisher(
-    publisherId: json['publisherId'] as String,
+    publisherId: json['publisherId'] as String?,
   );
 }
 

--- a/test/pubdev_api_test.dart
+++ b/test/pubdev_api_test.dart
@@ -59,6 +59,13 @@ void main() {
       final publisher = await client.packagePublisher(packageName);
       expect(publisher.publisherId, 'fvm.app');
     });
+
+    test('Get package publisher if unregistered', () async {
+      final unregisterPublisher =
+          await client.packagePublisher('freezed_annotation');
+      expect(unregisterPublisher.publisherId, null);
+    });
+
     test('Get Package Score', () async {
       final payload = await client.packageScore(packageName);
 


### PR DESCRIPTION
Thanks for your great package.

### Problem

When you use `getPublisher()` if the package unregistered `publisher`, returns below error because non-nullable cast in freezed.

```
type 'Null' is not a subtype of type 'String' in type cast
```

### Solution

In fact, a number of developers do not register `publisher`.
for example, even [freezed_annotaion](https://pub.dev/packages/freezed_annotation) that is probably major package.

So, `getPublisher()` should return nullable String.

thanks.