### PR TITLE
Getting packageScore and packageMetrics no longer throws if a package has not been scanned

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -1,10 +1,7 @@
-```dart
 import 'package:pub_api_client/pub_api_client.dart';
 
 void main() async {
   final client = PubClient();
-  final packageInfo = await client.getPackage('fvm');
-  print('Package Info: $packageInfo');
+  final packageScore = await client.packageScore('fvm');
+  print('Package Score: $packageScore');
 }
-
-```

--- a/lib/src/models/package_score_model.dart
+++ b/lib/src/models/package_score_model.dart
@@ -7,10 +7,10 @@ part 'package_score_model.g.dart';
 @freezed
 class PackageScore with _$PackageScore {
   factory PackageScore({
-    required final int grantedPoints,
-    required final int maxPoints,
+    required final int? grantedPoints,
+    required final int? maxPoints,
     required final int likeCount,
-    required final double popularityScore,
+    required final double? popularityScore,
     required final DateTime lastUpdated,
   }) = _PackageScore;
 

--- a/lib/src/models/package_score_model.freezed.dart
+++ b/lib/src/models/package_score_model.freezed.dart
@@ -21,10 +21,10 @@ class _$PackageScoreTearOff {
   const _$PackageScoreTearOff();
 
   _PackageScore call(
-      {required int grantedPoints,
-      required int maxPoints,
+      {required int? grantedPoints,
+      required int? maxPoints,
       required int likeCount,
-      required double popularityScore,
+      required double? popularityScore,
       required DateTime lastUpdated}) {
     return _PackageScore(
       grantedPoints: grantedPoints,
@@ -45,10 +45,10 @@ const $PackageScore = _$PackageScoreTearOff();
 
 /// @nodoc
 mixin _$PackageScore {
-  int get grantedPoints => throw _privateConstructorUsedError;
-  int get maxPoints => throw _privateConstructorUsedError;
+  int? get grantedPoints => throw _privateConstructorUsedError;
+  int? get maxPoints => throw _privateConstructorUsedError;
   int get likeCount => throw _privateConstructorUsedError;
-  double get popularityScore => throw _privateConstructorUsedError;
+  double? get popularityScore => throw _privateConstructorUsedError;
   DateTime get lastUpdated => throw _privateConstructorUsedError;
 
   Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
@@ -63,10 +63,10 @@ abstract class $PackageScoreCopyWith<$Res> {
           PackageScore value, $Res Function(PackageScore) then) =
       _$PackageScoreCopyWithImpl<$Res>;
   $Res call(
-      {int grantedPoints,
-      int maxPoints,
+      {int? grantedPoints,
+      int? maxPoints,
       int likeCount,
-      double popularityScore,
+      double? popularityScore,
       DateTime lastUpdated});
 }
 
@@ -90,11 +90,11 @@ class _$PackageScoreCopyWithImpl<$Res> implements $PackageScoreCopyWith<$Res> {
       grantedPoints: grantedPoints == freezed
           ? _value.grantedPoints
           : grantedPoints // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       maxPoints: maxPoints == freezed
           ? _value.maxPoints
           : maxPoints // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       likeCount: likeCount == freezed
           ? _value.likeCount
           : likeCount // ignore: cast_nullable_to_non_nullable
@@ -102,7 +102,7 @@ class _$PackageScoreCopyWithImpl<$Res> implements $PackageScoreCopyWith<$Res> {
       popularityScore: popularityScore == freezed
           ? _value.popularityScore
           : popularityScore // ignore: cast_nullable_to_non_nullable
-              as double,
+              as double?,
       lastUpdated: lastUpdated == freezed
           ? _value.lastUpdated
           : lastUpdated // ignore: cast_nullable_to_non_nullable
@@ -119,10 +119,10 @@ abstract class _$PackageScoreCopyWith<$Res>
       __$PackageScoreCopyWithImpl<$Res>;
   @override
   $Res call(
-      {int grantedPoints,
-      int maxPoints,
+      {int? grantedPoints,
+      int? maxPoints,
       int likeCount,
-      double popularityScore,
+      double? popularityScore,
       DateTime lastUpdated});
 }
 
@@ -148,11 +148,11 @@ class __$PackageScoreCopyWithImpl<$Res> extends _$PackageScoreCopyWithImpl<$Res>
       grantedPoints: grantedPoints == freezed
           ? _value.grantedPoints
           : grantedPoints // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       maxPoints: maxPoints == freezed
           ? _value.maxPoints
           : maxPoints // ignore: cast_nullable_to_non_nullable
-              as int,
+              as int?,
       likeCount: likeCount == freezed
           ? _value.likeCount
           : likeCount // ignore: cast_nullable_to_non_nullable
@@ -160,7 +160,7 @@ class __$PackageScoreCopyWithImpl<$Res> extends _$PackageScoreCopyWithImpl<$Res>
       popularityScore: popularityScore == freezed
           ? _value.popularityScore
           : popularityScore // ignore: cast_nullable_to_non_nullable
-              as double,
+              as double?,
       lastUpdated: lastUpdated == freezed
           ? _value.lastUpdated
           : lastUpdated // ignore: cast_nullable_to_non_nullable
@@ -183,13 +183,13 @@ class _$_PackageScore implements _PackageScore {
       _$_$_PackageScoreFromJson(json);
 
   @override
-  final int grantedPoints;
+  final int? grantedPoints;
   @override
-  final int maxPoints;
+  final int? maxPoints;
   @override
   final int likeCount;
   @override
-  final double popularityScore;
+  final double? popularityScore;
   @override
   final DateTime lastUpdated;
 
@@ -241,23 +241,23 @@ class _$_PackageScore implements _PackageScore {
 
 abstract class _PackageScore implements PackageScore {
   factory _PackageScore(
-      {required int grantedPoints,
-      required int maxPoints,
+      {required int? grantedPoints,
+      required int? maxPoints,
       required int likeCount,
-      required double popularityScore,
+      required double? popularityScore,
       required DateTime lastUpdated}) = _$_PackageScore;
 
   factory _PackageScore.fromJson(Map<String, dynamic> json) =
       _$_PackageScore.fromJson;
 
   @override
-  int get grantedPoints => throw _privateConstructorUsedError;
+  int? get grantedPoints => throw _privateConstructorUsedError;
   @override
-  int get maxPoints => throw _privateConstructorUsedError;
+  int? get maxPoints => throw _privateConstructorUsedError;
   @override
   int get likeCount => throw _privateConstructorUsedError;
   @override
-  double get popularityScore => throw _privateConstructorUsedError;
+  double? get popularityScore => throw _privateConstructorUsedError;
   @override
   DateTime get lastUpdated => throw _privateConstructorUsedError;
   @override

--- a/lib/src/models/package_score_model.g.dart
+++ b/lib/src/models/package_score_model.g.dart
@@ -8,10 +8,10 @@ part of 'package_score_model.dart';
 
 _$_PackageScore _$_$_PackageScoreFromJson(Map<String, dynamic> json) {
   return _$_PackageScore(
-    grantedPoints: json['grantedPoints'] as int,
-    maxPoints: json['maxPoints'] as int,
+    grantedPoints: json['grantedPoints'] as int?,
+    maxPoints: json['maxPoints'] as int?,
     likeCount: json['likeCount'] as int,
-    popularityScore: (json['popularityScore'] as num).toDouble(),
+    popularityScore: (json['popularityScore'] as num?)?.toDouble(),
     lastUpdated: DateTime.parse(json['lastUpdated'] as String),
   );
 }

--- a/lib/src/pub_api_client_base.dart
+++ b/lib/src/pub_api_client_base.dart
@@ -78,9 +78,14 @@ class PubClient {
   }
 
   /// Returns the `PackageMetrics` for package [packageName]
-  Future<PackageMetrics> packageMetrics(String packageName) async {
-    final data = await _fetch(endpoint.packageMetrics(packageName));
-    return PackageMetrics.fromJson(data);
+  Future<PackageMetrics?> packageMetrics(String packageName) async {
+    try {
+      final data = await _fetch(endpoint.packageMetrics(packageName));
+      return PackageMetrics.fromJson(data);
+    } on NotFoundException {
+      // If the package has not been scanned, the server will return 404
+      return null;
+    }
   }
 
   /// Returns the `PackageOptions` for package [packageName]

--- a/test/pubdev_api_test.dart
+++ b/test/pubdev_api_test.dart
@@ -36,9 +36,11 @@ void main() {
       final score = await client.packageScore(packageName);
       final metrics = await client.packageMetrics(packageName);
 
-      expect(metrics.score, score);
-      expect(metrics.scorecard.packageName, 'fvm');
-      expect(metrics.scorecard.maxPubPoints, maxPoints);
+      if (metrics != null) {
+        expect(metrics.score, score);
+        expect(metrics.scorecard.packageName, 'fvm');
+        expect(metrics.scorecard.maxPubPoints, maxPoints);
+      }
     });
 
     test('Get package version info', () async {


### PR DESCRIPTION
Turns out getPackageMetrics gives 404 as well if the package hasn't been scanned yet