### PR TITLE
Add missing field to pubspec

### DIFF
--- a/lib/src/models/barrel.dart
+++ b/lib/src/models/barrel.dart
@@ -4,5 +4,6 @@ export 'package:pub_api_client/src/models/package_options_model.dart';
 export 'package:pub_api_client/src/models/package_publisher_model.dart';
 export 'package:pub_api_client/src/models/package_score_model.dart';
 export 'package:pub_api_client/src/models/pub_package_model.dart';
+export 'package:pub_api_client/src/models/pubspec_extensions.dart';
 export 'package:pub_api_client/src/models/search_order.dart';
 export 'package:pub_api_client/src/models/search_results_model.dart';

--- a/lib/src/models/pubspec_extensions.dart
+++ b/lib/src/models/pubspec_extensions.dart
@@ -1,5 +1,4 @@
 import 'package:pubspec/pubspec.dart';
-import 'package:yaml/yaml.dart';
 
 /// {@template pubspec_extensions}
 /// Extensions on [PubSpec] to provide additional functionality.
@@ -15,11 +14,11 @@ extension PubspecExtensions on PubSpec {
   String? issueTracker() => unParsedYaml?['issue_tracker'];
 
   /// Optional. List of URLs where users can sponsor development of the package.
-  YamlList? funding() => unParsedYaml?['funding'];
+  List? funding() => unParsedYaml?['funding'];
 
   /// Optional. Specify files to ignore when conducting a pre-publishing search
   /// for potential leaks of secrets.
-  YamlList? falseSecrets() => unParsedYaml?['false_secrets'];
+  List? falseSecrets() => unParsedYaml?['false_secrets'];
 
   /// Optional. Specify a list of screenshot files to display on pub.dev
   List<Screenshot>? screenshots() {
@@ -35,10 +34,10 @@ extension PubspecExtensions on PubSpec {
   }
 
   /// Optional field to list the topics that this packages belongs to.
-  YamlList? topics() => unParsedYaml?['topics'];
+  List? topics() => unParsedYaml?['topics'];
 
   /// Optional. List of ignored security advisories.
-  YamlList? ignoredAdvisories() => unParsedYaml?['ignored_advisories'];
+  List? ignoredAdvisories() => unParsedYaml?['ignored_advisories'];
 }
 
 /// {@template screenshot}

--- a/lib/src/models/pubspec_extensions.dart
+++ b/lib/src/models/pubspec_extensions.dart
@@ -1,0 +1,72 @@
+import 'package:pubspec/pubspec.dart';
+import 'package:yaml/yaml.dart';
+
+/// {@template pubspec_extensions}
+/// Extensions on [PubSpec] to provide additional functionality.
+///
+/// Following the pubspec file definition on dart.dev
+/// https://dart.dev/tools/pub/pubspec
+/// {@endtemplate}
+extension PubspecExtensions on PubSpec {
+  /// Optional. URL pointing to the package's source code repository.
+  String? repository() => unParsedYaml?['repository'];
+
+  /// Optional. URL pointing to an issue tracker for the package.
+  String? issueTracker() => unParsedYaml?['issue_tracker'];
+
+  /// Optional. List of URLs where users can sponsor development of the package.
+  YamlList? funding() => unParsedYaml?['funding'];
+
+  /// Optional. Specify files to ignore when conducting a pre-publishing search
+  /// for potential leaks of secrets.
+  YamlList? falseSecrets() => unParsedYaml?['false_secrets'];
+
+  /// Optional. Specify a list of screenshot files to display on pub.dev
+  List<Screenshot>? screenshots() {
+    final screenShotList = unParsedYaml?['screenshots'];
+    if (screenShotList == null) {
+      return null;
+    }
+    final List<Screenshot> screenshots = [];
+    for (final screenShot in screenShotList) {
+      screenshots.add(Screenshot.fromJson(screenShot));
+    }
+    return screenshots;
+  }
+
+  /// Optional field to list the topics that this packages belongs to.
+  YamlList? topics() => unParsedYaml?['topics'];
+
+  /// Optional. List of ignored security advisories.
+  YamlList? ignoredAdvisories() => unParsedYaml?['ignored_advisories'];
+}
+
+/// {@template screenshot}
+/// A screenshot of the package to display on pub.dev.
+/// {@endtemplate}
+class Screenshot {
+  const Screenshot(this.path, this.description);
+
+  final String path;
+  final String description;
+
+  factory Screenshot.fromJson(Map json) => Screenshot(
+        json['path'] as String,
+        json['description'] as String,
+      );
+
+  @override
+  String toString() => 'Screenshot(path: $path, description: $description)';
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is Screenshot &&
+        other.path == path &&
+        other.description == description;
+  }
+
+  @override
+  int get hashCode => path.hashCode ^ description.hashCode;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,6 @@ dependencies:
   oauth2: ^2.0.2
   path: ^1.8.3
   pubspec: ^2.3.0
-  yaml: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   oauth2: ^2.0.2
   path: ^1.8.3
   pubspec: ^2.3.0
+  yaml: ^3.1.2
 
 dev_dependencies:
   build_runner: ^2.4.6

--- a/test/pubspec_extensions_test.dart
+++ b/test/pubspec_extensions_test.dart
@@ -1,4 +1,4 @@
-import 'package:pub_api_client/src/models/pubspec_extensions.dart';
+import 'package:pub_api_client/pub_api_client.dart';
 import 'package:pubspec/pubspec.dart';
 import 'package:test/test.dart';
 import 'package:yaml/yaml.dart';

--- a/test/pubspec_extensions_test.dart
+++ b/test/pubspec_extensions_test.dart
@@ -1,0 +1,81 @@
+import 'package:pub_api_client/src/models/pubspec_extensions.dart';
+import 'package:pubspec/pubspec.dart';
+import 'package:test/test.dart';
+import 'package:yaml/yaml.dart';
+
+void main() {
+  test('Should be able to parse repository field', () async {
+    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
+    expect(pubspec.repository(), 'https://foo.bar/repo');
+  });
+
+  test('Should be able to parse issue tracker field', () async {
+    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
+    expect(pubspec.issueTracker(), 'https://foo.bar/issues');
+  });
+
+  test('Should be able to parse funding field', () async {
+    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
+    final sponsors = pubspec.funding();
+    expect(sponsors, isA<YamlList>());
+    expect(sponsors, hasLength(2));
+    expect(sponsors?[0], 'https://foo.bar/sponsor1');
+    expect(sponsors?[1], 'https://foo.bar/sponsor2');
+  });
+
+  test('Should be able to parse false secrets field', () async {
+    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
+    final falseSecrets = pubspec.falseSecrets();
+    expect(falseSecrets, isA<YamlList>());
+    expect(falseSecrets, hasLength(2));
+    expect(falseSecrets?[0], '/lib/foo/bar.dart');
+    expect(falseSecrets?[1], '/lib/bar/foo.dart');
+  });
+
+  test('Should be able to parse screenshots field', () async {
+    final screenshots = pubspec.screenshots();
+
+    expect(screenshots, isA<List<Screenshot>>());
+    expect(screenshots, hasLength(1));
+
+    final firstScreenShot = screenshots?[0];
+    expect(firstScreenShot, isA<Screenshot>());
+    expect(firstScreenShot?.description, 'foo-bar screenshot');
+    expect(firstScreenShot?.path, 'screenshots/foo-bar.png');
+  });
+
+  test('Should be able to parse topics field', () async {
+    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
+    final topics = pubspec.topics();
+    expect(topics, isA<YamlList>());
+    expect(topics, hasLength(2));
+    expect(topics?[0], 'bar');
+    expect(topics?[1], 'foo');
+  });
+
+  test('Should be able to parse ignoredAdvisories field', () async {
+    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
+    final ignoredAdvisories = pubspec.ignoredAdvisories();
+    expect(ignoredAdvisories, isA<YamlList>());
+    expect(ignoredAdvisories, hasLength(2));
+    expect(ignoredAdvisories?[0], 'foo-bar');
+    expect(ignoredAdvisories?[1], 'bar-foo');
+  });
+}
+
+const pubspec = PubSpec(
+  unParsedYaml: {
+    'repository': 'https://foo.bar/repo',
+    'issue_tracker': 'https://foo.bar/issues',
+    'funding': ['https://foo.bar/sponsor1', 'https://foo.bar/sponsor2'],
+    'false_secrets': ['/lib/foo/bar.dart', '/lib/bar/foo.dart'],
+    'topics': ['bar', 'foo'],
+    'ignored_advisories': ['foo-bar', 'bar-foo'],
+    'screenshots': [
+      {
+        'description': 'foo-bar screenshot',
+        'path': 'screenshots/foo-bar.png',
+      }
+    ],
+  },
+);

--- a/test/pubspec_extensions_test.dart
+++ b/test/pubspec_extensions_test.dart
@@ -1,32 +1,27 @@
 import 'package:pub_api_client/pub_api_client.dart';
 import 'package:pubspec/pubspec.dart';
 import 'package:test/test.dart';
-import 'package:yaml/yaml.dart';
 
 void main() {
   test('Should be able to parse repository field', () async {
-    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
     expect(pubspec.repository(), 'https://foo.bar/repo');
   });
 
   test('Should be able to parse issue tracker field', () async {
-    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
     expect(pubspec.issueTracker(), 'https://foo.bar/issues');
   });
 
   test('Should be able to parse funding field', () async {
-    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
     final sponsors = pubspec.funding();
-    expect(sponsors, isA<YamlList>());
+    expect(sponsors, isA<List>());
     expect(sponsors, hasLength(2));
     expect(sponsors?[0], 'https://foo.bar/sponsor1');
     expect(sponsors?[1], 'https://foo.bar/sponsor2');
   });
 
   test('Should be able to parse false secrets field', () async {
-    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
     final falseSecrets = pubspec.falseSecrets();
-    expect(falseSecrets, isA<YamlList>());
+    expect(falseSecrets, isA<List>());
     expect(falseSecrets, hasLength(2));
     expect(falseSecrets?[0], '/lib/foo/bar.dart');
     expect(falseSecrets?[1], '/lib/bar/foo.dart');
@@ -45,18 +40,16 @@ void main() {
   });
 
   test('Should be able to parse topics field', () async {
-    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
     final topics = pubspec.topics();
-    expect(topics, isA<YamlList>());
+    expect(topics, isA<List>());
     expect(topics, hasLength(2));
     expect(topics?[0], 'bar');
     expect(topics?[1], 'foo');
   });
 
   test('Should be able to parse ignoredAdvisories field', () async {
-    final pubspec = await PubSpec.loadFile('test/example_pubspec.yaml');
     final ignoredAdvisories = pubspec.ignoredAdvisories();
-    expect(ignoredAdvisories, isA<YamlList>());
+    expect(ignoredAdvisories, isA<List>());
     expect(ignoredAdvisories, hasLength(2));
     expect(ignoredAdvisories?[0], 'foo-bar');
     expect(ignoredAdvisories?[1], 'bar-foo');


### PR DESCRIPTION
Addressing Issue #46 

Adding missing values which can occur in a pubspec to the PubSpec Package using extension methods.
I implemented methods which are listed here https://dart.dev/tools/pub/pubspec, but aren't part of the PubSpec package.

Also added a set of test to make sure parsing is working as expected