### PR TITLE
chore: finalize 3.2.0 release changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 ## Unreleased
 
-- Expose discontinued/advisory metadata on `PubPackage` and drop the large cached fixture from version control [#75](https://github.com/leoafarias/pub_api_client/pull/75)
-- Include the GitHub repository URL in the default `User-Agent` header [#69](https://github.com/leoafarias/pub_api_client/issues/69)
-- Improve WWW-Authenticate header parsing for authorization errors [#70](https://github.com/leoafarias/pub_api_client/issues/70)
+- No changes yet.
 
 ## 3.2.0
 
+- Expose discontinued/advisory metadata on `PubPackage` and drop the large cached fixture from version control [#75](https://github.com/leoafarias/pub_api_client/pull/75)
+- Include the GitHub repository URL in the default `User-Agent` header [#69](https://github.com/leoafarias/pub_api_client/issues/69)
+- Improve WWW-Authenticate header parsing for authorization errors [#70](https://github.com/leoafarias/pub_api_client/issues/70)
 - Make `lastUpdated` optional by @Rexios80 in [#61](https://github.com/leoafarias/pub_api_client/pull/61)
 
 ## 3.1.1


### PR DESCRIPTION
## Summary
Finalize the changelog for version 3.2.0 by moving completed features from Unreleased to the 3.2.0 section.

This includes:
- Advisory metadata exposure and fixture optimization
- GitHub URL in User-Agent header
- Improved WWW-Authenticate header parsing